### PR TITLE
ajout du fichier dockerfile

### DIFF
--- a/prototype/.dockerignore
+++ b/prototype/.dockerignore
@@ -1,0 +1,3 @@
+.env
+__pycache__/
+.venv

--- a/prototype/Dockerfile
+++ b/prototype/Dockerfile
@@ -1,0 +1,18 @@
+# Étape 1 : Utiliser une image de base Python
+FROM python:3.10-slim
+
+# Étape 2 : Définir le répertoire de travail
+WORKDIR /app
+
+# Étape 3 : Copier le fichier des dépendances et les installer
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Étape 4 : Copier TOUT le reste du code de l'application
+COPY . .
+
+# Étape 5 : Exposer le port par défaut de Streamlit
+EXPOSE 8501
+
+# Étape 6 : Définir la commande de démarrage pour une application Streamlit
+CMD ["streamlit", "run", "main.py"]


### PR DESCRIPTION
## Summary by Sourcery

Add Dockerfile and dockerignore to enable containerization of the Streamlit prototype

Build:
- Add Dockerfile to build the prototype using Python 3.10-slim, install dependencies, copy code, expose port 8501, and launch Streamlit
- Add .dockerignore file to optimize Docker build context